### PR TITLE
commentout omniauth mail_deliver

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,9 +64,10 @@ class User < ApplicationRecord
                       password: Devise.friendly_token[0, 20])
     user.skip_confirmation!
     user.save
-    if user.password
-      NotificationMailer.send_password_for_github_registration(user).deliver
-    end
+		##初期パスワードの通知メール　セキュリティ面を考えて除外
+    # if user.password
+      # NotificationMailer.send_password_for_github_registration(user).deliver
+    # end
     user
   end
 end


### PR DESCRIPTION
セキュリティ面を考えて初期パスワードのメール通知機能をコメントアウト